### PR TITLE
Pipgio::setISRFunc java doc tweak

### DIFF
--- a/pigpioj-java/src/main/java/uk/pigpioj/PigpioGpio.java
+++ b/pigpioj-java/src/main/java/uk/pigpioj/PigpioGpio.java
@@ -220,8 +220,8 @@ public class PigpioGpio {
 	 * succession may be missed by the kernel (i.e. this mechanism can not be used
 	 * to capture several interrupts only a few microseconds apart)
 	 * @param gpio GPIO
-	 * @param edge None / Rising / Falling / None
-	 * @param timeout Timeout
+	 * @param edge RISING_EDGE, FALLING_EDGE, or EITHER_EDGE
+	 * @param timeout interrupt timeout in milliseconds (<=0 to cancel)
 	 * @param callback Callback function
 	 * @return Status
 	 */


### PR DESCRIPTION
I looked at the native code in pigpioj and the docs on http://abyz.me.uk/rpi/pigpio/cif.html#gpioSetISRFuncEx suggests edge only takes three values. I just copied the entry from abyz as those constants match the ones in PigpioConstants. Obviously not a big issue.